### PR TITLE
feat: allow timezone customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,11 @@ RUN pip install --user -r requirements.txt pyinstaller --no-warn-script-location
 
 COPY aps2mqtt/ /app/aps2mqtt
 WORKDIR /app
-RUN /root/.local/bin/pyinstaller --onefile /app/aps2mqtt/__main__.py -n aps2mqtt
+RUN /root/.local/bin/pyinstaller --collect-all tzdata --onefile /app/aps2mqtt/__main__.py -n aps2mqtt
 
 FROM ubuntu:jammy AS runner
+RUN apt update && apt install tzdata -y && apt clean && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/dist/aps2mqtt /app/
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -116,12 +116,21 @@ APS2MQTT configuration can be provided by a yaml config file or by environment v
 |---|---|---|---|
 | APS_ECU_IP | IP of the ECU | "192.168.1.42" | None, this field id mandatory |
 | APS_ECU_PORT | Communication port of the ECU | 8899 | 8899 |
+| APS_ECU_TIMEZONE | Timezone of the ECU | 'Europe/Paris' | None (use system timezone) |
 | APS_ECU_AUTO_RESTART | Automatically restart ECU in case of error | True | False |
 | APS_ECU_WIFI_SSID | SSID of the ECU Wifi <br />:information_source: Only used if automatic restart is enabled | "My Wifi" | "" |
 | APS_ECU_WIFI_PASSWD | Password of the ECU Wifi <br />:information_source: Only used if automatic restart is enabled | "secret-key" | "" |
 | APS_ECU_STOP_AT_NIGHT | Stop ECU query during the night | True | False |
 | APS_ECU_POSITION_LAT | Latitude of the ECU, used to retrieve sunset and sunrise <br />:information_source: Only used if stop at night is enabled | 51.49819 | 48.864716 (Paris) |
 | APS_ECU_POSITION_LNG | Longitude of the ECU, used to retrieve sunset and sunrise <br />:information_source: Only used if stop at night is enabled | -0.13087 | 2.349014 (Paris) |
+
+### Timezone
+
+Without any specific configuration, aps2mqtt use your system's timezone as a reference.
+
+* If you use aps2mqtt as a python application, setting the ECU timezone is recommended by setting the configuration variable 'APS_ECU_TIMEZONE' for better processing.  
+
+* If you are using aps2mqtt as a Docker image, you can configure the timezone for the whole container using the environement variable 'TZ'
 
 ### Example
 
@@ -130,6 +139,7 @@ APS2MQTT configuration can be provided by a yaml config file or by environment v
 ``` yaml
 ecu:
   APS_ECU_IP: '192.168.1.42'
+  APS_ECU_TIMEZONE: 'Europe/Paris'
   APS_ECU_STOP_AT_NIGHT: True
   APS_ECU_POSITION_LAT: 47.206
   APS_ECU_POSITION_LNG: -1.5645
@@ -146,6 +156,7 @@ mqtt:
 ``` yaml
 ecu:
   APS_ECU_IP: '192.168.1.42'
+  APS_ECU_TIMEZONE: 'Europe/Paris'
   APS_ECU_STOP_AT_NIGHT: True
   APS_ECU_POSITION_LAT: 47.206
   APS_ECU_POSITION_LNG: -1.5645
@@ -165,6 +176,8 @@ services:
     image: fligneul/aps2mqtt:latest
     restart: always
     environment:
+      - TZ=Europe/Paris
+      - DEBUG=True
       - APS_ECU_IP=192.168.1.42
       - APS_ECU_STOP_AT_NIGHT=True
       - APS_ECU_POSITION_LAT=47.206
@@ -174,7 +187,6 @@ services:
       - MQTT_BROKER_USER=johndoe
       - MQTT_BROKER_PASSWD=itsasecret
       - MQTT_BROKER_SECURED_CONNECTION=True
-      - DEBUG=True
 ```
 
 ## MQTT topics

--- a/aps2mqtt/apsystems/ECU.py
+++ b/aps2mqtt/apsystems/ECU.py
@@ -1,6 +1,6 @@
 """Handle ECU requests"""
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 import requests
 from suntime import Sun
 from aps2mqtt.apsystems.APSystemsSocket import APSystemsSocket, APSystemsInvalidData
@@ -34,17 +34,17 @@ class ECU:
                 and self.cached_data.get("qty_of_online_inverters", 0) == 0
             )
             and (
-                datetime.now(timezone.utc) < self.ecu_location.get_sunrise_time()
-                or datetime.now(timezone.utc) > self.ecu_location.get_sunset_time()
+                datetime.now().astimezone() < self.ecu_location.get_local_sunrise_time()
+                or datetime.now().astimezone() > self.ecu_location.get_local_sunset_time()
             )
         )
 
     def wake_up_time(self):
-        if self.ecu_location.get_sunrise_time() < datetime.now(timezone.utc):
-            return self.ecu_location.get_sunrise_time(
-                datetime.now(timezone.utc).date() + timedelta(days=1)
+        if self.ecu_location.get_local_sunrise_time() < datetime.now().astimezone():
+            return self.ecu_location.get_local_sunrise_time(
+                datetime.now().astimezone().date() + timedelta(days=1)
             )
-        return self.ecu_location.get_sunrise_time()
+        return self.ecu_location.get_local_sunrise_time()
 
     def invalid_data(self):
         # we got invalid data, increment retry counter

--- a/aps2mqtt/config.py
+++ b/aps2mqtt/config.py
@@ -1,5 +1,6 @@
 """Application config classes, can be set by file or env variable"""
 import os
+from zoneinfo import ZoneInfo
 import yaml
 from str2bool import str2bool_exc
 
@@ -27,6 +28,8 @@ class ECUConfig:
     def __init__(self, cfg):
         self.ipaddr = cfg["APS_ECU_IP"]
         self.port = int(cfg.get("APS_ECU_PORT", 8899))
+        ecu_timezone = cfg.get("APS_ECU_TIMEZONE", os.getenv("TZ", None))
+        self.timezone = ZoneInfo(str(ecu_timezone)) if ecu_timezone is not None else None
         self.auto_restart = str2bool_exc(str(cfg.get("APS_ECU_AUTO_RESTART", False)))
         if self.auto_restart:
             self.wifi_config = WifiConfig(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ setuptools>=65.5.1
 twine==4.0.2
 python-semantic-release==8.3.0
 str2bool==1.1
+tzdata==2023.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     numpy~=1.26
     suntime~=1.2
     str2bool~=1.1
+    tzdata~=2023
 
 [options.packages.find]
 include = aps2mqtt, aps2mqtt.*


### PR DESCRIPTION
Add timezone customisation (fix #16)

Timezone can be customised

- At container level using TZ env variable
- For ECU only if the ECU is not running in the same timezone as the container using APS_ECU_TIMEZONE config variable
- Log are now displaying timezone for better debugging
