### PR TITLE
feat: Add MQTT message retention and client status topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ APS2MQTT configuration can be provided by a yaml config file or by environment v
 | MQTT_BROKER_PASSWD | User password of the MQTT broker | "itsasecret" | "" |
 | MQTT_CLIENT_ID | Client ID if the MQTT client | "MyAwesomeClient" | "APS2MQTT" |
 | MQTT_TOPIC_PREFIX | Topic prefix for publishing | "my-personal-topic" | "" |
+| MQTT_RETAIN | Retain MQTT messages | True | False |
 | MQTT_BROKER_SECURED_CONNECTION | Use secure connection to MQTT broker | True | False |
 | MQTT_BROKER_CACERTS_PATH | Path to the cacerts file | "/User/johndoe/.ssl/cacerts" | None |
 
@@ -150,6 +151,7 @@ mqtt:
   MQTT_BROKER_PORT: 1883
   MQTT_BROKER_USER: 'johndoe'
   MQTT_BROKER_PASSWD: 'itsasecret'
+  MQTT_RETAIN: True
 ```
 
 #### Secured connection
@@ -193,6 +195,8 @@ services:
 ## MQTT topics
 
 The aps2mqtt retrieve from the whole PV array as a whole as well as each individual inverter in detail.
+
+* aps/status - current status of the service, `online` or `offline`. The `offline` message is sent using LWT
 
 ### ECU data
 

--- a/aps2mqtt/config.py
+++ b/aps2mqtt/config.py
@@ -15,6 +15,7 @@ class MQTTConfig:
         self.broker_passwd = cfg.get("MQTT_BROKER_PASSWD", "")
         self.client_id = cfg.get("MQTT_CLIENT_ID", "APS2MQTT")
         self.topic_prefix = cfg.get("MQTT_TOPIC_PREFIX", "")
+        self.retain = str2bool_exc(str(cfg.get("MQTT_RETAIN", False)))
         self.secured_connection = str2bool_exc(
             str(cfg.get("MQTT_BROKER_SECURED_CONNECTION", False))
         )


### PR DESCRIPTION
Introduce a new configuration option `MQTT_RETAIN` to control MQTT message retention. When enabled, all published messages (except the Last Will and Testament) will be retained by the broker.

Additionally, implement an MQTT Last Will and Testament (LWT) feature to publish the online/offline status of the `aps2mqtt` instance on a dedicated status topic (`aps/status`). This topic
will be updated to "online" upon successful connection and "offline" upon unexpected disconnection or graceful shutdown.

The `README.md` has been updated to reflect these new features and configuration options.